### PR TITLE
Auto-index badge data and enrich badge metadata

### DIFF
--- a/website/components/BadgeCard.jsx
+++ b/website/components/BadgeCard.jsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+import ProgressBar from "./ProgressBar";
+import { getBadgeProgress } from "../lib/store";
+
+export default function BadgeCard({ badge }) {
+  const progress = getBadgeProgress(badge.badgeId);
+  return (
+    <div style={{border:"1px solid #ddd", borderRadius:12, padding:16, marginBottom:12}}>
+      <h3 style={{margin:"0 0 8px"}}>{badge.title}</h3>
+      <div style={{display:"flex", gap:16, alignItems:"center"}}>
+        <ProgressBar value={progress.percent || 0}/>
+        <Link href={`/badges/${badge.badgeId}`}>Open</Link>
+      </div>
+      {!progress.purchased && <div style={{fontSize:12, color:"#666", marginTop:8}}>${badge.priceUSD || 20} per badge</div>}
+    </div>
+  );
+}

--- a/website/components/ProgressBar.jsx
+++ b/website/components/ProgressBar.jsx
@@ -1,0 +1,12 @@
+export default function ProgressBar({ value=0 }) {
+  const pct = Math.round(value * 100);
+  return (
+    <div style={{border:"1px solid #ccc", borderRadius:8, padding:2, width:"100%", maxWidth:260}}>
+      <div style={{
+        height:12, width:`${pct}%`, borderRadius:6, background:"#4caf50",
+        transition:"width .3s ease"
+      }} />
+      <div style={{fontSize:12, marginTop:4}}>{pct}% complete</div>
+    </div>
+  );
+}

--- a/website/dashboard.html
+++ b/website/dashboard.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Thunderbird Merit Badges | Scout Dashboard</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="./scripts.js" defer></script>
+  </head>
+  <body class="page page--dashboard">
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="brand" href="./index.html">
+          <span class="brand__mark" aria-hidden="true">🦅</span>
+          <span class="brand__text">Thunderbird Merit Badges</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary">
+          <a class="site-nav__link" href="./index.html">Home</a>
+          <a class="site-nav__link" href="./info.html">Badges &amp; Info</a>
+          <a class="site-nav__link" href="./payment.html">Pricing &amp; Payment</a>
+          <a class="site-nav__link site-nav__link--cta" href="./dashboard.html">My Dashboard</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="section section--narrow" data-dashboard>
+        <div class="section__header">
+          <h1>Scout Dashboard</h1>
+          <p>Track your requirements, celebrate wins, and know your next step.</p>
+        </div>
+
+        <div class="callout callout--info" data-dashboard-empty hidden>
+          <h2>No profile found</h2>
+          <p>
+            We could not find a saved scout profile on this device. Visit the
+            <a href="./login.html">login page</a> to create one, then return to
+            the dashboard.
+          </p>
+        </div>
+
+        <div class="dashboard" data-dashboard-content hidden>
+          <section class="dashboard__header">
+            <div>
+              <h2 class="dashboard__title">Welcome back, <span data-scout-name></span>!</h2>
+              <p class="dashboard__subtitle">
+                Troop <span data-scout-troop></span> &bull; Progress pace:
+                <span data-scout-pace></span>
+              </p>
+            </div>
+            <button class="button button--ghost" type="button" data-download-summary>
+              Download Summary / Blue Card
+            </button>
+          </section>
+
+          <section class="dashboard__panel">
+            <h3>Badge Progress</h3>
+            <div class="dashboard__badges" data-badge-progress></div>
+          </section>
+
+          <section class="dashboard__panel">
+            <h3>Add another badge</h3>
+            <form class="inline-form" data-add-badge-form>
+              <label class="inline-form__field">
+                <span class="sr-only">Select badge</span>
+                <select name="badgeName" required></select>
+              </label>
+              <button class="button" type="submit">Add Badge</button>
+            </form>
+          </section>
+
+          <section class="dashboard__panel">
+            <h3>Next recommended action</h3>
+            <div class="dashboard__recommendation" data-next-action>
+              Keep up the great work! Update your reflections after completing
+              today&rsquo;s activity.
+            </div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>Remember: review all conversations with a registered merit badge counselor.</p>
+    </footer>
+  </body>
+</html>

--- a/website/data/american-business.json
+++ b/website/data/american-business.json
@@ -1,0 +1,68 @@
+{
+  "badgeId": "american-business",
+  "title": "American Business",
+  "summary": "Learn how businesses work, plan a simple venture, track results, and understand ethics, marketing, and investing basics.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/american-business/",
+  "resources": [
+    {
+      "title": "SBA Learning Center",
+      "url": "https://www.sba.gov/learning-center",
+      "description": "Free mini-courses on planning, financing, and managing small businesses."
+    },
+    {
+      "title": "Junior Achievement – Student Programs",
+      "url": "https://jausa.ja.org/programs",
+      "description": "Entrepreneurship and personal finance activities geared toward teens."
+    },
+    {
+      "title": "Investopedia: Introduction to Business",
+      "url": "https://www.investopedia.com/guides/starting-business/",
+      "description": "Plain-language guide to core concepts like revenue, profit, and cash flow."
+    }
+  ],
+  "modules": [
+    {
+      "id": "how-business-works",
+      "title": "How Business Works",
+      "minutes": 35,
+      "type": "reading",
+      "instructions": "Define revenue, cost, profit, cash flow, and break-even in your own words. Give a real-world example for two terms."
+    },
+    {
+      "id": "micro-venture-plan",
+      "title": "Plan a Micro-Venture",
+      "minutes": 90,
+      "type": "project",
+      "instructions": "Plan a simple business (lawn care, tutoring, crafts). Upload a 1-page plan: product/service, customers, price, costs, and expected profit."
+    },
+    {
+      "id": "run-and-track",
+      "title": "Run & Track Results",
+      "minutes": 120,
+      "type": "report",
+      "instructions": "Operate your venture for a short period OR simulate with 3–5 transactions. Upload a basic ledger (date, item, revenue, cost) and a profit summary."
+    },
+    {
+      "id": "marketing-ethics",
+      "title": "Marketing & Ethics",
+      "minutes": 45,
+      "type": "reflection",
+      "prompt": "Draft a simple ad or flyer. Then write a paragraph on truthful advertising and one ethical choice you’d make as an owner."
+    },
+    {
+      "id": "investing-basics",
+      "title": "Investing Basics",
+      "minutes": 40,
+      "type": "quiz",
+      "quiz": [
+        { "q": "What is diversification?", "a": "Spreading investments to reduce risk." },
+        { "q": "Stocks vs. bonds (one difference)?", "a": "Stocks = ownership and variable returns; bonds = loans with fixed interest." }
+      ]
+    }
+  ],
+  "checkpoints": [
+    { "id": "mid", "label": "Plan Review", "after": "micro-venture-plan" },
+    { "id": "final", "label": "Final Review", "after": "run-and-track" }
+  ]
+}

--- a/website/data/american-heritage.json
+++ b/website/data/american-heritage.json
@@ -1,0 +1,65 @@
+{
+  "badgeId": "american-heritage",
+  "title": "American Heritage",
+  "summary": "Explore pivotal eras, visit historic places, analyze media about the past, and share how U.S. history shapes life today.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/american-heritage/",
+  "resources": [
+    {
+      "title": "National Archives – Educator Resources",
+      "url": "https://www.archives.gov/education",
+      "description": "Primary source documents, lesson ideas, and virtual exhibits."
+    },
+    {
+      "title": "Smithsonian National Museum of American History",
+      "url": "https://americanhistory.si.edu/exhibitions",
+      "description": "Browse major exhibits and artifacts that shaped U.S. history."
+    },
+    {
+      "title": "Library of Congress – Chronicling America",
+      "url": "https://chroniclingamerica.loc.gov/",
+      "description": "Historic newspapers for researching people, places, and events."
+    }
+  ],
+  "modules": [
+    {
+      "id": "eras-overview",
+      "title": "Major Eras Overview",
+      "minutes": 40,
+      "type": "reading",
+      "instructions": "List five key U.S. historical eras and one defining event/person for each. Add 2–3 sentences on why each mattered."
+    },
+    {
+      "id": "local-history",
+      "title": "Local History Connections",
+      "minutes": 45,
+      "type": "research",
+      "instructions": "Choose a local site, person, or event. Write a 1-page summary linking it to a national theme (e.g., migration, industry, civil rights)."
+    },
+    {
+      "id": "site-visit",
+      "title": "Historic Site or Museum Visit",
+      "minutes": 90,
+      "type": "report",
+      "instructions": "Visit or take a virtual tour. Upload 3–5 notes/photos and a 1-page report: what you saw, era represented, and what you learned."
+    },
+    {
+      "id": "media-analysis",
+      "title": "History in Media",
+      "minutes": 60,
+      "type": "reflection",
+      "prompt": "Watch a film, documentary, or exhibit on a U.S. topic. In 2–3 paragraphs, note what seemed accurate, what might be dramatized, and one source you checked."
+    },
+    {
+      "id": "share-the-story",
+      "title": "Share What You Learned",
+      "minutes": 45,
+      "type": "project",
+      "instructions": "Create a short presentation, poster, or post (3–5 minutes or 300–500 words) to teach others one American Heritage topic. Upload your file or video link."
+    }
+  ],
+  "checkpoints": [
+    { "id": "mid", "label": "Midpoint Review", "after": "site-visit" },
+    { "id": "final", "label": "Final Review", "after": "share-the-story" }
+  ]
+}

--- a/website/data/bird-study.json
+++ b/website/data/bird-study.json
@@ -1,0 +1,65 @@
+{
+  "badgeId": "bird-study",
+  "title": "Bird Study",
+  "summary": "Build identification skills, keep a field notebook, explore habitats and conservation, and share your observations.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/bird-study/",
+  "resources": [
+    {
+      "title": "Cornell Lab – All About Birds",
+      "url": "https://www.allaboutbirds.org/news/",
+      "description": "Field guides, ID tips, and seasonal birding advice."
+    },
+    {
+      "title": "Audubon Bird Guide App",
+      "url": "https://www.audubon.org/app",
+      "description": "Free mobile guide with photos, sounds, and habitat info."
+    },
+    {
+      "title": "Merlin Bird ID",
+      "url": "https://merlin.allaboutbirds.org/",
+      "description": "Instant identification help using photos or songs."
+    }
+  ],
+  "modules": [
+    {
+      "id": "id-basics",
+      "title": "Identification Basics",
+      "minutes": 40,
+      "type": "reading",
+      "instructions": "Describe how to ID birds using size/shape, field marks, behavior, habitat, and voice. List three local species with one distinguishing trait each."
+    },
+    {
+      "id": "field-notebook",
+      "title": "Field Notebook",
+      "minutes": 120,
+      "type": "project",
+      "instructions": "Keep a notebook with at least 6 observations on different days. For each: date, time, location, weather, species (or 'unknown'), behavior, and sketch/photo if possible."
+    },
+    {
+      "id": "habitats",
+      "title": "Habitats & Adaptations",
+      "minutes": 45,
+      "type": "reflection",
+      "prompt": "Pick two species and explain how their beaks, feet, or behavior fit their habitat."
+    },
+    {
+      "id": "conservation",
+      "title": "Conservation & Ethics",
+      "minutes": 35,
+      "type": "reading",
+      "instructions": "Summarize two threats to birds in your area (e.g., habitat loss, window strikes, invasive species) and one action you can take at home or school."
+    },
+    {
+      "id": "share-observations",
+      "title": "Share Your Observations",
+      "minutes": 45,
+      "type": "project",
+      "instructions": "Create a 3–5 minute presentation or one-page report highlighting three birds you observed. Include maps or checklists if you used them."
+    }
+  ],
+  "checkpoints": [
+    { "id": "mid", "label": "Notebook Check", "after": "field-notebook" },
+    { "id": "final", "label": "Final Review", "after": "share-observations" }
+  ]
+}

--- a/website/data/chess.json
+++ b/website/data/chess.json
@@ -1,0 +1,67 @@
+{
+  "badgeId": "chess",
+  "title": "Chess",
+  "summary": "Learn the rules and notation, practice tactics, play complete games, and teach others the joy of chess.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/chess/",
+  "resources": [
+    {
+      "title": "lichess.org – Learn",
+      "url": "https://lichess.org/learn",
+      "description": "Interactive lessons covering piece moves, tactics, and checkmate patterns."
+    },
+    {
+      "title": "ChessKid Video Lessons",
+      "url": "https://www.chesskid.com/videos",
+      "description": "Kid-friendly videos on openings, tactics, and endgames."
+    },
+    {
+      "title": "U.S. Chess Federation – Rules & Resources",
+      "url": "https://new.uschess.org/play",
+      "description": "Official rules, tournament finder, and scholastic chess tips."
+    }
+  ],
+  "modules": [
+    {
+      "id": "rules-notation",
+      "title": "Rules & Notation",
+      "minutes": 40,
+      "type": "quiz",
+      "quiz": [
+        { "q": "How does the knight move?", "a": "In an L-shape: two squares in one direction and one perpendicular; may jump pieces." },
+        { "q": "What is castling?", "a": "A king/rook move for safety: king two squares toward rook; rook to the square the king passed over (no checks/pieces between/previous moves)." }
+      ]
+    },
+    {
+      "id": "tactics",
+      "title": "Core Tactics",
+      "minutes": 45,
+      "type": "reading",
+      "instructions": "Define fork, pin, skewer, discovered attack, and double check. Upload a diagram or brief example of any two."
+    },
+    {
+      "id": "openings-and-endgames",
+      "title": "Openings & Endgames",
+      "minutes": 50,
+      "type": "reflection",
+      "prompt": "Describe one opening principle (control center, develop pieces, king safety) and one basic endgame idea (opposition, triangulation, promotion)."
+    },
+    {
+      "id": "play-games",
+      "title": "Play Complete Games",
+      "minutes": 90,
+      "type": "report",
+      "instructions": "Play three full games (OTB or online). Upload PGNs or brief move lists and a 3–5 sentence takeaway for each game."
+    },
+    {
+      "id": "teach-someone",
+      "title": "Teach Someone",
+      "minutes": 45,
+      "type": "project",
+      "instructions": "Teach the rules to a beginner or run a mini-lesson for peers (15–20 min). Upload an outline and a photo or short reflection of how it went."
+    }
+  ],
+  "checkpoints": [
+    { "id": "final", "label": "Counselor Review", "after": "teach-someone" }
+  ]
+}

--- a/website/data/citizenship-community.json
+++ b/website/data/citizenship-community.json
@@ -1,0 +1,65 @@
+{
+  "badgeId": "citizenship-community",
+  "title": "Citizenship in the Community",
+  "summary": "Learn how local government works, how public meetings run, how issues surface, and where you can pitch in to improve your community.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/citizenship-in-the-community/",
+  "resources": [
+    {
+      "title": "National League of Cities – Civic Education",
+      "url": "https://www.nlc.org/resource/civic-education/",
+      "description": "Background on how local governments operate and engage residents."
+    },
+    {
+      "title": "ICMA Student Resources",
+      "url": "https://icma.org/students",
+      "description": "Explains the roles of city and county managers with case studies."
+    },
+    {
+      "title": "USA.gov – Local Governments",
+      "url": "https://www.usa.gov/local-governments",
+      "description": "Directory and overview of counties, municipalities, and special districts."
+    }
+  ],
+  "modules": [
+    {
+      "id": "belonging",
+      "title": "Citizenship: The Value of Belonging",
+      "minutes": 30,
+      "type": "reflection",
+      "prompt": "In 2–3 paragraphs, explain what 'citizenship' means in your daily life and list two obligations and two rights you have in your community."
+    },
+    {
+      "id": "local-structure",
+      "title": "How Local Governments Are Structured",
+      "minutes": 45,
+      "type": "reading",
+      "instructions": "Summarize how counties, municipalities, school districts, and special districts divide responsibilities where you live. Add one example for each."
+    },
+    {
+      "id": "public-meeting",
+      "title": "Observe a Public Meeting",
+      "minutes": 90,
+      "type": "report",
+      "instructions": "Attend (or watch a recording of) a city/town/school board meeting. Record agenda items, one debated issue, and how representatives voted. Submit a 1-page objective report."
+    },
+    {
+      "id": "local-issue",
+      "title": "Identify a Local Issue",
+      "minutes": 60,
+      "type": "research",
+      "instructions": "Pick a real local issue (e.g., traffic, park access, zoning). Interview or email one local official or informed adult. Summarize the issue, stakeholders, and one way youth can help."
+    },
+    {
+      "id": "service",
+      "title": "Make a Difference",
+      "minutes": 180,
+      "type": "serviceLog",
+      "instructions": "Plan and complete a community contribution (e.g., clean-up, info flyer, small advocacy step). Log what you did, hours, who benefited, and outcomes."
+    }
+  ],
+  "checkpoints": [
+    {"id":"cpA","label":"Midpoint Review","after":"public-meeting"},
+    {"id":"final","label":"Final Counselor Review","after":"service"}
+  ]
+}

--- a/website/data/citizenship-nation.json
+++ b/website/data/citizenship-nation.json
@@ -1,0 +1,69 @@
+{
+  "badgeId": "citizenship-nation",
+  "title": "Citizenship in the Nation",
+  "summary": "Explore the founding ideas, the Constitution and Bill of Rights, three branches, and how national issues are debated in a representative republic.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/citizenship-in-the-nation/",
+  "resources": [
+    {
+      "title": "National Constitution Center – Interactive Constitution",
+      "url": "https://constitutioncenter.org/interactive-constitution",
+      "description": "Clause-by-clause explanations with essays from scholars across perspectives."
+    },
+    {
+      "title": "iCivics: Branches of Power",
+      "url": "https://www.icivics.org/games/branches-power",
+      "description": "Online game exploring checks and balances across the three branches."
+    },
+    {
+      "title": "Library of Congress – Congress.gov Resources for Students",
+      "url": "https://www.congress.gov/resources/display/content/Students+Resources",
+      "description": "Guides to how federal laws are made and where to follow current bills."
+    }
+  ],
+  "modules": [
+    {
+      "id": "foundations",
+      "title": "Foundations of American Democracy",
+      "minutes": 40,
+      "type": "reading",
+      "instructions": "Summarize the five core democratic concepts listed at the start of the pamphlet and explain one modern example for each."
+    },
+    {
+      "id": "constitution-billofrights",
+      "title": "Constitution & Bill of Rights",
+      "minutes": 60,
+      "type": "quiz",
+      "quiz": [
+        {"q": "What does 'popular sovereignty' mean?", "a": "The people hold supreme power and establish the government."},
+        {"q": "Name two protections in the First Amendment.", "a": "Any two of: religion, speech, press, assembly, petition."},
+        {"q": "What does the 10th Amendment reserve?", "a": "Powers not delegated to the federal government are reserved to the states or the people."}
+      ]
+    },
+    {
+      "id": "branches",
+      "title": "Three Branches & Checks",
+      "minutes": 45,
+      "type": "reading",
+      "instructions": "Create a simple chart listing the primary powers of Congress, the President, and the Supreme Court and one check each has on another branch."
+    },
+    {
+      "id": "national-issues",
+      "title": "National Issue Brief",
+      "minutes": 90,
+      "type": "research",
+      "instructions": "Choose a national issue (e.g., national security, economy, civil liberties). Write a 1-page balanced brief explaining two perspectives and a reasoned recommendation."
+    },
+    {
+      "id": "representative-letter",
+      "title": "Write Your Representative",
+      "minutes": 45,
+      "type": "reflection",
+      "prompt": "Draft a respectful letter to your U.S. Representative or Senators explaining your position on the issue from the prior module. Attach the draft."
+    }
+  ],
+  "checkpoints": [
+    {"id":"cpA","label":"Foundations Review","after":"constitution-billofrights"},
+    {"id":"final","label":"Final Counselor Review","after":"representative-letter"}
+  ]
+}

--- a/website/data/citizenship-world.json
+++ b/website/data/citizenship-world.json
@@ -1,0 +1,60 @@
+{
+  "badgeId": "citizenship-world",
+  "title": "Citizenship in the World",
+  "summary": "Understand how nations govern, how international systems work, and how global issues and alliances affect daily life.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/citizenship-in-the-world/",
+  "resources": [
+    {
+      "title": "U.S. Department of State – Discover Diplomacy",
+      "url": "https://diplomacy.state.gov/discover-diplomacy/",
+      "description": "Explains how diplomats represent national interests around the world."
+    },
+    {
+      "title": "Council on Foreign Relations – World101",
+      "url": "https://world101.cfr.org/",
+      "description": "Short lessons on global systems, foreign policy tools, and current issues."
+    },
+    {
+      "title": "Model United Nations Guide for Students",
+      "url": "https://unausa.org/model-united-nations/",
+      "description": "Tips for researching countries, writing position papers, and debating respectfully."
+    }
+  ],
+  "modules": [
+    {
+      "id": "world-citizenship",
+      "title": "What Is Citizenship? (Global View)",
+      "minutes": 35,
+      "type": "reading",
+      "instructions": "Define citizenship, list two ways it’s acquired, and explain how rights/duties differ across governments."
+    },
+    {
+      "id": "systems",
+      "title": "Comparative Political Systems",
+      "minutes": 60,
+      "type": "quiz",
+      "quiz": [
+        {"q":"Define autocracy, oligarchy, democracy, and republic in one sentence each.","a":"Autocracy: power in one; Oligarchy: power in few; Democracy: rule by people/majority; Republic: elected reps with limited government protecting rights."},
+        {"q":"What is 'limited government' sometimes called?","a":"Rule of law."}
+      ]
+    },
+    {
+      "id": "national-interest",
+      "title": "National Interest & Foreign Policy",
+      "minutes": 50,
+      "type": "reading",
+      "instructions": "Summarize the three key areas of national interest and describe one real example for each (security, economic welfare, values)."
+    },
+    {
+      "id": "global-issues",
+      "title": "Global Issues Brief",
+      "minutes": 90,
+      "type": "research",
+      "instructions": "Pick a global challenge (e.g., pandemics, migration, climate, WMD proliferation). Write a 1-page overview, impacted regions, and two cooperative responses."
+    }
+  ],
+  "checkpoints": [
+    {"id":"final","label":"Counselor Review","after":"global-issues"}
+  ]
+}

--- a/website/data/communication.json
+++ b/website/data/communication.json
@@ -1,0 +1,67 @@
+{
+  "badgeId": "communication",
+  "title": "Communication",
+  "summary": "Build clear speaking, listening, and planning skills for school, Scouting, and life — from five-minute talks to leading a group discussion.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/communication/",
+  "resources": [
+    {
+      "title": "Toastmasters Youth Leadership Program",
+      "url": "https://www.toastmasters.org/education/youth-leadership-program",
+      "description": "Workshops that build public speaking confidence for teens."
+    },
+    {
+      "title": "TED-Ed Student Talk Resources",
+      "url": "https://ed.ted.com/student_talks",
+      "description": "Guides and planning worksheets for crafting engaging presentations."
+    },
+    {
+      "title": "Purdue OWL – Public Speaking Tips",
+      "url": "https://owl.purdue.edu/owl/general_writing/specific_writing/public_speaking/",
+      "description": "Advice on outlining, visuals, and practicing speeches effectively."
+    }
+  ],
+  "modules": [
+    {
+      "id": "listening",
+      "title": "Good Listener, Good Leader",
+      "minutes": 35,
+      "type": "reflection",
+      "prompt": "Keep a one-day communication log and list three listening techniques you used. What changed when you applied them?"
+    },
+    {
+      "id": "five-minute-speech",
+      "title": "The Five-Minute Speech",
+      "minutes": 60,
+      "type": "project",
+      "instructions": "Draft a 5-minute talk (outline + key cards). Record a practice run and upload notes or video. Aim for a story-hook, clear body, and memorable close."
+    },
+    {
+      "id": "teach-or-pitch",
+      "title": "Teach or Pitch",
+      "minutes": 45,
+      "type": "project",
+      "instructions": "Teach a skill with aids OR make a short sales pitch (attention → need → solution → close). Upload your plan and a 60–120s recording."
+    },
+    {
+      "id": "lead-discussion",
+      "title": "Lead a Small-Group Discussion",
+      "minutes": 45,
+      "type": "report",
+      "instructions": "Plan and moderate a 10–15 min group discussion (topic, ground rules, timekeeping). Submit agenda + brief outcomes."
+    },
+    {
+      "id": "media-choices",
+      "title": "Choosing the Right Medium",
+      "minutes": 25,
+      "type": "quiz",
+      "quiz": [
+        {"q":"Name two situations best suited to a formal letter.","a":"Applications/requests; thank-you/recognition; letters to editor."},
+        {"q":"Why proofread email before sending?","a":"Clarity, tone, grammar affect how your message is received and your professionalism."}
+      ]
+    }
+  ],
+  "checkpoints": [
+    {"id":"final","label":"Counselor Review","after":"lead-discussion"}
+  ]
+}

--- a/website/data/engineering.json
+++ b/website/data/engineering.json
@@ -1,0 +1,68 @@
+{
+  "badgeId": "engineering",
+  "title": "Engineering",
+  "summary": "Discover engineering fields, apply the design process, build and test a small prototype, and reflect on safety and teamwork.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/engineering/",
+  "resources": [
+    {
+      "title": "TryEngineering",
+      "url": "https://tryengineering.org/students/",
+      "description": "Hands-on activities and career spotlights across engineering disciplines."
+    },
+    {
+      "title": "NASA Jet Propulsion Laboratory STEM Lessons",
+      "url": "https://www.jpl.nasa.gov/edu/teach/",
+      "description": "Design challenges and lesson plans focused on space exploration engineering."
+    },
+    {
+      "title": "DiscoverE – Future City Resources",
+      "url": "https://discovere.org/resources/",
+      "description": "Project ideas and videos that highlight teamwork, safety, and innovation."
+    }
+  ],
+  "modules": [
+    {
+      "id": "fields-and-roles",
+      "title": "Fields & Roles",
+      "minutes": 40,
+      "type": "reading",
+      "instructions": "List four engineering disciplines (e.g., civil, mechanical, electrical, environmental) and an example project for each."
+    },
+    {
+      "id": "design-process",
+      "title": "Design Process",
+      "minutes": 45,
+      "type": "quiz",
+      "quiz": [
+        { "q": "Put these in order: prototype, define problem, test, brainstorm.", "a": "Define problem → Brainstorm → Prototype → Test" },
+        { "q": "Why iterate?", "a": "Testing reveals improvements; iteration optimizes performance and safety." }
+      ]
+    },
+    {
+      "id": "prototype",
+      "title": "Build a Prototype",
+      "minutes": 120,
+      "type": "project",
+      "instructions": "Design and build a small device (bridge, catapult, gear toy, sensor mount). Upload sketch, materials list, photos, and what you tested."
+    },
+    {
+      "id": "test-and-iterate",
+      "title": "Test & Iterate",
+      "minutes": 60,
+      "type": "report",
+      "instructions": "Record 2–3 test trials (what changed, results). Explain one improvement you made and why."
+    },
+    {
+      "id": "safety-and-ethics",
+      "title": "Safety & Ethics",
+      "minutes": 30,
+      "type": "reflection",
+      "prompt": "List three safety steps you followed while building/testing and one ethical responsibility engineers have to the public."
+    }
+  ],
+  "checkpoints": [
+    { "id": "mid", "label": "Design Review", "after": "prototype" },
+    { "id": "final", "label": "Final Review", "after": "test-and-iterate" }
+  ]
+}

--- a/website/data/family-life.json
+++ b/website/data/family-life.json
@@ -1,0 +1,67 @@
+{
+  "badgeId": "family-life",
+  "title": "Family Life",
+  "summary": "Strengthen your home team: what a family is, how to communicate, share responsibilities, plan meetings, and complete service together.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/family-life/",
+  "resources": [
+    {
+      "title": "American Academy of Pediatrics – HealthyChildren.org Family Life",
+      "url": "https://www.healthychildren.org/English/family-life/",
+      "description": "Articles on communication, routines, and supporting one another at home."
+    },
+    {
+      "title": "Utah State University Extension – Family Meetings Guide",
+      "url": "https://extension.usu.edu/familyrelationships/quality-time/family-meetings",
+      "description": "Step-by-step advice for planning productive family meetings."
+    },
+    {
+      "title": "DoSomething.org – Family Service Ideas",
+      "url": "https://www.dosomething.org/us/articles/family-volunteering-ideas",
+      "description": "Project ideas for serving together and tracking impact."
+    }
+  ],
+  "modules": [
+    {
+      "id": "what-is-family",
+      "title": "What Is a Family?",
+      "minutes": 30,
+      "type": "reading",
+      "instructions": "List five positive family traits (e.g., love, security, respect, trust, time together) and give one example you’ve seen at home."
+    },
+    {
+      "id": "responsibilities",
+      "title": "Shared Roles & Responsibilities",
+      "minutes": 40,
+      "type": "project",
+      "instructions": "Create a one-week home duties chart (room care, meals, general chores). Track completion and reflect on what changed."
+    },
+    {
+      "id": "family-meeting",
+      "title": "Run a Family Meeting",
+      "minutes": 45,
+      "type": "report",
+      "instructions": "Set an agenda, ground rules, and a simple problem-solving plan. Include at least one topic from: chores, tech use, finances, or family project. Upload notes."
+    },
+    {
+      "id": "family-service",
+      "title": "Family Service Project",
+      "minutes": 180,
+      "type": "serviceLog",
+      "instructions": "Plan and complete a small service or improvement (home, neighborhood, or community). Log who did what, hours, and results."
+    },
+    {
+      "id": "time-money",
+      "title": "Managing Time & Money",
+      "minutes": 35,
+      "type": "quiz",
+      "quiz": [
+        {"q":"Name two time-management practices families can use.","a":"To-do lists/priorities; shared schedule; buffer time; divide chores; weekly meeting."},
+        {"q":"What’s a simple first step in budgeting?","a":"Track income and expenses; separate fixed vs. flexible costs; set goals."}
+      ]
+    }
+  ],
+  "checkpoints": [
+    {"id":"final","label":"Counselor Review","after":"family-service"}
+  ]
+}

--- a/website/data/reading.json
+++ b/website/data/reading.json
@@ -1,0 +1,84 @@
+{
+  "badgeId": "reading",
+  "title": "Reading",
+  "summary": "Discover why reading matters, explore genres, practice finding reliable info, stay safe online, and complete a reading-focused service project.",
+  "priceUSD": 20,
+  "officialUrl": "https://www.scouting.org/merit-badges/reading/",
+  "resources": [
+    {
+      "title": "Library of Congress – Kids & Families",
+      "url": "https://www.loc.gov/families/",
+      "description": "Digital storytimes, exhibits, and activities."
+    },
+    {
+      "title": "How to Choose a Book",
+      "url": "https://www.readbrightly.com/how-to-choose-a-book/",
+      "description": "Quick tips for finding books you’ll enjoy."
+    },
+    {
+      "title": "CrashCourse: How and Why We Read (video)",
+      "url": "https://www.youtube.com/watch?v=MSYw502dJNY",
+      "description": "Short explainer on the power of reading."
+    }
+  ],
+  "modules": [
+    {
+      "id": "why-read",
+      "title": "Why Read?",
+      "minutes": 30,
+      "type": "reflection",
+      "prompt": "In 2–3 minutes (text or audio), describe what you want reading to do for you this year."
+    },
+    {
+      "id": "fun",
+      "title": "Reading for Fun",
+      "minutes": 120,
+      "type": "readingLog",
+      "instructions": "Log 4+ books across different types/genres. For each: title, author, pages, why you chose it, 3–5 sentence takeaway."
+    },
+    {
+      "id": "library",
+      "title": "Using the Library",
+      "minutes": 30,
+      "type": "catalog",
+      "instructions": "Do an Author, Title, and Subject search; record one call number and shelf location."
+    },
+    {
+      "id": "info",
+      "title": "Reading for Information",
+      "minutes": 90,
+      "type": "research",
+      "instructions": "Find 3+ sources in mixed formats. Submit a one-page summary plus 1–2 credibility notes per source."
+    },
+    {
+      "id": "internet",
+      "title": "Online Safety",
+      "minutes": 25,
+      "type": "quiz",
+      "quiz": [
+        { "q": "True/False: Share your last name at will on public sites.", "a": "False" },
+        {
+          "q": "Best password behavior?",
+          "choices": ["Share with friend", "Reuse across sites", "Keep private; share only with parent/guardian"],
+          "a": "Keep private; share only with parent/guardian"
+        },
+        {
+          "q": "A stranger asks to meet to trade books. What do you do?",
+          "a": "Decline and tell a parent/guardian; never meet without family approval."
+        }
+      ]
+    },
+    {
+      "id": "service",
+      "title": "Volunteering for Reading",
+      "minutes": 240,
+      "type": "serviceLog",
+      "instructions": "≥4 hours. Options: read-aloud, help library, book drive, Little Free Library. Log hours + photo/note."
+    }
+  ],
+  "checkpoints": [
+    { "id": "cpA", "label": "Checkpoint A", "after": "fun" },
+    { "id": "cpB", "label": "Checkpoint B", "after": "info" },
+    { "id": "final", "label": "Final Review", "after": "service" }
+  ]
+}

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Thunderbird Merit Badges | Home</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="./scripts.js" defer></script>
+  </head>
+  <body class="page page--home">
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="brand" href="./index.html">
+          <span class="brand__mark" aria-hidden="true">🦅</span>
+          <span class="brand__text">Thunderbird Merit Badges</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary">
+          <a class="site-nav__link" href="./index.html">Home</a>
+          <a class="site-nav__link" href="./info.html">Badges &amp; Info</a>
+          <a class="site-nav__link" href="./payment.html">Pricing &amp; Payment</a>
+          <a class="site-nav__link site-nav__link--cta" href="./login.html">Scout Login</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero__content">
+          <h1 class="hero__title">Earn merit badges with confidence.</h1>
+          <p class="hero__subtitle">
+            Thunderbird Merit Badges is your always-open academy where scouts can
+            learn, reflect, and demonstrate mastery at their own pace with AI
+            guidance and verified Scoutmaster oversight.
+          </p>
+          <div class="hero__actions">
+            <a class="button" href="./login.html">Get Started</a>
+            <a class="button button--ghost" href="./info.html">See How It Works</a>
+          </div>
+        </div>
+        <div class="hero__panel">
+          <div class="hero__card">
+            <h2 class="hero__card-title">Featured Eagle Track</h2>
+            <ul class="hero__badge-list">
+              <li>Citizenship in the Community</li>
+              <li>Citizenship in the Nation</li>
+              <li>Citizenship in the World</li>
+              <li>Family Life</li>
+              <li>Personal Fitness</li>
+              <li>Personal Management</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="section__header">
+          <h2>Why Thunderbird?</h2>
+          <p>
+            A modern academy rooted in Scouting values. We blend technology with
+            Youth Protection best practices to keep every scout on track.
+          </p>
+        </div>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <h3>AI Learning Partner</h3>
+            <p>
+              Interactive prompts powered by ChatGPT help scouts brainstorm
+              project ideas, write reflections, and prepare for blue card
+              conversations.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Scoutmaster Oversight</h3>
+            <p>
+              Every badge is reviewed by registered adults who monitor progress
+              and verify completion for council-ready documentation.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Progress You Can See</h3>
+            <p>
+              Colorful dashboards and badge thermometers show exactly where each
+              requirement stands&mdash;and what to do next.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Safe &amp; Compliant</h3>
+            <p>
+              Built-in content filters, conversation logs, and two-deep leadership
+              tools maintain a safe learning environment for every scout.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section__header">
+          <h2>How it works</h2>
+        </div>
+        <ol class="steps">
+          <li class="steps__item">
+            <h3>Create your scout profile</h3>
+            <p>
+              Scouts sign in with name, troop number, and parent or guardian
+              contact details for accountability.
+            </p>
+          </li>
+          <li class="steps__item">
+            <h3>Select your badges</h3>
+            <p>
+              Choose from Eagle-required badges today, with more merit badges on
+              the way.
+            </p>
+          </li>
+          <li class="steps__item">
+            <h3>Learn, reflect, and submit</h3>
+            <p>
+              The AI guide suggests activities, checks responses, and prepares a
+              completion summary and blue card for your unit leader.
+            </p>
+          </li>
+        </ol>
+      </section>
+
+      <section class="section section--accent">
+        <div class="cta">
+          <div>
+            <h2>Ready to start your next badge?</h2>
+            <p>
+              Login to build your dashboard, or explore our program highlights
+              and pricing first.
+            </p>
+          </div>
+          <div class="cta__actions">
+            <a class="button button--light" href="./login.html">Login</a>
+            <a class="button button--outline" href="./payment.html">View Pricing</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>
+        &copy; <span data-year></span> Thunderbird Merit Badges. Built with
+        Scouts BSA values and Youth Protection in mind.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/website/info.html
+++ b/website/info.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Thunderbird Merit Badges | Program Info</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="./scripts.js" defer></script>
+  </head>
+  <body class="page page--info">
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="brand" href="./index.html">
+          <span class="brand__mark" aria-hidden="true">🦅</span>
+          <span class="brand__text">Thunderbird Merit Badges</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary">
+          <a class="site-nav__link" href="./index.html">Home</a>
+          <a class="site-nav__link" href="./info.html">Badges &amp; Info</a>
+          <a class="site-nav__link" href="./payment.html">Pricing &amp; Payment</a>
+          <a class="site-nav__link site-nav__link--cta" href="./login.html">Scout Login</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="section section--narrow">
+        <div class="section__header">
+          <h1>About Thunderbird Merit Badges</h1>
+          <p>
+            Thunderbird Merit Badges is a blended learning experience built for
+            busy scouts. Our digital guide helps you navigate badge requirements
+            while human leaders provide feedback, accountability, and sign-off.
+          </p>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="section__header">
+          <h2>Available merit badges</h2>
+          <p>
+            We are launching with the six Eagle-required badges that benefit most
+            from flexible pacing and reflection. More badges will be added as the
+            academy grows.
+          </p>
+        </div>
+        <div class="badge-grid" data-badge-grid></div>
+      </section>
+
+      <section class="section section--narrow">
+        <div class="info-split">
+          <article class="info-panel">
+            <h2>AI-assisted, scout-led</h2>
+            <p>
+              Our ChatGPT-powered mentor provides open-ended prompts, project
+              suggestions, and reflection checklists that encourage scouts to own
+              their learning journey.
+            </p>
+            <ul class="checklist">
+              <li>Requirement-by-requirement prompts and examples</li>
+              <li>Automated spelling and clarity suggestions</li>
+              <li>Progress notes saved for blue card summaries</li>
+            </ul>
+          </article>
+          <article class="info-panel">
+            <h2>Two-deep verified oversight</h2>
+            <p>
+              Registered adults monitor every conversation transcript. Live
+              sessions always include at least two leaders, and parents receive a
+              weekly activity digest.
+            </p>
+            <ul class="checklist">
+              <li>Content moderation filters and flagging tools</li>
+              <li>Audit-ready conversation history</li>
+              <li>Secure storage that meets BSA Youth Protection guidelines</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="section section--accent">
+        <div class="cta">
+          <div>
+            <h2>Want to bring Thunderbird to your council?</h2>
+            <p>
+              We offer white-label deployments and leader training for district or
+              council-level programs.
+            </p>
+          </div>
+          <div class="cta__actions">
+            <a class="button button--light" href="mailto:partnerships@thunderbirdbadges.org">Contact Partnerships</a>
+            <a class="button button--outline" href="./payment.html">Review Pricing</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>Questions? Reach us at <a href="mailto:info@thunderbirdbadges.org">info@thunderbirdbadges.org</a>.</p>
+    </footer>
+  </body>
+</html>

--- a/website/lib/store.js
+++ b/website/lib/store.js
@@ -1,0 +1,57 @@
+// LocalStorage-backed store for demo/MVP
+const KEY = "tmb_progress_v1";
+
+function loadAll() {
+  if (typeof window === "undefined") return {};
+  try { return JSON.parse(localStorage.getItem(KEY) || "{}"); } catch { return {}; }
+}
+function saveAll(obj) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(KEY, JSON.stringify(obj));
+}
+
+export function getScout() {
+  const all = loadAll();
+  return all.scout || { name: "", troop: "", parentEmail: "", city: "", state: "" };
+}
+export function setScout(data) {
+  const all = loadAll();
+  all.scout = { ...(all.scout||{}), ...data };
+  saveAll(all);
+}
+
+export function getBadgeProgress(badgeId) {
+  const all = loadAll();
+  return (all.badges && all.badges[badgeId]) || { purchased: false, modules: {}, percent: 0 };
+}
+export function updateModule(badgeId, moduleId, payload) {
+  const all = loadAll();
+  all.badges = all.badges || {};
+  const b = all.badges[badgeId] || { purchased: false, modules: {}, percent: 0 };
+  b.modules[moduleId] = { ...(b.modules[moduleId]||{}), ...payload, done: true, updatedAt: new Date().toISOString() };
+  // recompute percent: simple proportion of modules marked done
+  const done = Object.values(b.modules).filter(m => m.done).length;
+  const total = b.total || payload.totalModules || 6; // pass total via first update or set explicitly below
+  b.total = total;
+  b.percent = Math.min(1, done / total);
+  all.badges[badgeId] = b;
+  saveAll(all);
+  return b;
+}
+export function markPurchased(badgeId, purchased=true, totalModules=6) {
+  const all = loadAll();
+  all.badges = all.badges || {};
+  const b = all.badges[badgeId] || { modules:{}, percent:0 };
+  b.purchased = purchased;
+  b.total = totalModules;
+  all.badges[badgeId] = b;
+  saveAll(all);
+}
+export async function fetchBadges() {
+  const response = await fetch("/api/manifest");
+  if (!response.ok) {
+    throw new Error("Failed to load badges");
+  }
+  const { badges } = await response.json();
+  return badges;
+}

--- a/website/login.html
+++ b/website/login.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Thunderbird Merit Badges | Login</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="./scripts.js" defer></script>
+  </head>
+  <body class="page page--login">
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="brand" href="./index.html">
+          <span class="brand__mark" aria-hidden="true">🦅</span>
+          <span class="brand__text">Thunderbird Merit Badges</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary">
+          <a class="site-nav__link" href="./index.html">Home</a>
+          <a class="site-nav__link" href="./info.html">Badges &amp; Info</a>
+          <a class="site-nav__link" href="./payment.html">Pricing &amp; Payment</a>
+          <a class="site-nav__link site-nav__link--cta" href="./login.html">Scout Login</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="section section--narrow">
+        <div class="section__header">
+          <h1>Create or Resume Your Scout Profile</h1>
+          <p>
+            Fill out the form below to jump into your personalized badge
+            dashboard. We recommend completing the form together with a parent or
+            guardian.
+          </p>
+        </div>
+
+        <form class="form-card" data-login-form>
+          <fieldset class="form-fieldset">
+            <legend>Scout details</legend>
+            <label class="form-field">
+              <span>Scout name</span>
+              <input name="scoutName" type="text" autocomplete="name" required />
+            </label>
+            <label class="form-field">
+              <span>Troop number</span>
+              <input name="troop" type="text" inputmode="numeric" required />
+            </label>
+            <label class="form-field">
+              <span>Parent or guardian email</span>
+              <input name="parentEmail" type="email" autocomplete="parent email" required />
+            </label>
+            <label class="form-field">
+              <span>Emergency contact phone</span>
+              <input name="contactPhone" type="tel" autocomplete="tel" placeholder="(555) 123-4567" />
+            </label>
+          </fieldset>
+
+          <fieldset class="form-fieldset">
+            <legend>Select your badges</legend>
+            <p class="form-help">
+              Start with an Eagle-required badge or choose several. You can add
+              more anytime from your dashboard.
+            </p>
+            <div class="badge-select" data-badge-list></div>
+          </fieldset>
+
+          <fieldset class="form-fieldset">
+            <legend>Learning pace</legend>
+            <p class="form-help">
+              We use this to tailor milestone reminders and recommended check-ins
+              with your Scoutmaster.
+            </p>
+            <label class="radio-option">
+              <input type="radio" name="pace" value="weekly" checked />
+              <span>Weekly check-ins (recommended)</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="pace" value="biweekly" />
+              <span>Every other week</span>
+            </label>
+            <label class="radio-option">
+              <input type="radio" name="pace" value="monthly" />
+              <span>Once a month</span>
+            </label>
+          </fieldset>
+
+          <div class="form-actions">
+            <button class="button" type="submit">Save &amp; Continue</button>
+            <p class="form-footnote">
+              Already filled this out? Submit again to update your selections.
+            </p>
+          </div>
+        </form>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>
+        Need help? Email <a href="mailto:support@thunderbirdbadges.org">support@thunderbirdbadges.org</a>.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/website/pages/api/manifest.js
+++ b/website/pages/api/manifest.js
@@ -1,0 +1,25 @@
+import fs from "fs";
+import path from "path";
+
+export default function handler(req, res) {
+  try {
+    const dataDir = path.join(process.cwd(), "data");
+    const files = fs.readdirSync(dataDir).filter((file) => file.endsWith(".json"));
+
+    const badges = files.map((file) => {
+      const raw = fs.readFileSync(path.join(dataDir, file), "utf-8");
+      const json = JSON.parse(raw);
+      return {
+        badgeId: json.badgeId || file.replace(/\.json$/, ""),
+        title: json.title || json.badgeId || file.replace(/\.json$/, ""),
+        priceUSD: json.priceUSD ?? 20,
+      };
+    });
+
+    badges.sort((a, b) => a.title.localeCompare(b.title));
+    res.status(200).json({ badges });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Failed to load manifest." });
+  }
+}

--- a/website/pages/badges/[id].jsx
+++ b/website/pages/badges/[id].jsx
@@ -1,0 +1,105 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import ProgressBar from "../../components/ProgressBar";
+import { getBadgeProgress, updateModule, markPurchased } from "../../lib/store";
+
+export default function BadgePage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [badge, setBadge] = useState(null);
+  const [progress, setProgress] = useState(getBadgeProgress(id));
+
+  useEffect(() => {
+    if (!id) return;
+    import(`../../data/${id}.json`).then(mod => {
+      setBadge(mod);
+      // ensure total modules known for percent calc
+      markPurchased(id, getBadgeProgress(id).purchased || false, mod.modules.length);
+      setProgress(getBadgeProgress(id));
+    }).catch(() => setBadge(null));
+  }, [id]);
+
+  if (!id) return null;
+  if (badge === null) return <main style={{padding:24}}>Badge not found.</main>;
+  const purchased = getBadgeProgress(id).purchased;
+
+  const completeModule = (m) => {
+    const updated = updateModule(id, m.id, { totalModules: badge.modules.length });
+    setProgress(updated);
+  };
+
+  const handlePurchase = () => {
+    // placeholder; integrate Stripe later
+    markPurchased(id, true, badge.modules.length);
+    setProgress(getBadgeProgress(id));
+    alert("Purchased for demo purposes. (Integrate Stripe here.)");
+  };
+
+  return (
+    <main style={{maxWidth:820, margin:"40px auto", padding:"0 16px"}}>
+      <h1>{badge.title}</h1>
+      <p>{badge.summary}</p>
+      {badge.officialUrl && (
+        <p>
+          <a href={badge.officialUrl} target="_blank" rel="noreferrer">
+            View Official Requirements ↗
+          </a>
+        </p>
+      )}
+      {Array.isArray(badge.resources) && badge.resources.length > 0 && (
+        <div style={{border:"1px solid #eee", borderRadius:12, padding:12, margin:"12px 0"}}>
+          <strong>Explore More</strong>
+          <ul style={{marginTop:8}}>
+            {badge.resources.map((resource, index) => (
+              <li key={index}>
+                <a href={resource.url} target="_blank" rel="noreferrer">{resource.title}</a>
+                {resource.description ? (
+                  <>
+                    {" "}— <span style={{color:"#555"}}>{resource.description}</span>
+                  </>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div style={{margin:"12px 0"}}><ProgressBar value={progress.percent || 0}/></div>
+
+      {!purchased && (
+        <div style={{border:"1px dashed #aaa", padding:12, borderRadius:10, marginBottom:16}}>
+          <strong>Price:</strong> ${badge.priceUSD || 20}{" "}
+          <button onClick={handlePurchase} style={{marginLeft:8}}>Purchase Access</button>
+          <div style={{fontSize:12, color:"#666"}}>Discounts available for urban troops.</div>
+        </div>
+      )}
+
+      {badge.modules.map((m, idx) => {
+        const done = progress.modules?.[m.id]?.done;
+        return (
+          <div key={m.id} style={{border:"1px solid #eee", borderRadius:12, padding:16, marginBottom:12, opacity: purchased ? 1 : 0.5}}>
+            <h3 style={{marginTop:0}}>{idx+1}. {m.title}</h3>
+            <p style={{marginTop:4}}>
+              <em>Estimated:</em> {m.minutes} min • <em>Type:</em> {m.type}
+            </p>
+            {m.instructions && <p>{m.instructions}</p>}
+            {m.prompt && <p><strong>Prompt:</strong> {m.prompt}</p>}
+
+            {/* Minimal inputs to capture work (extend per type later) */}
+            {purchased ? (
+              <>
+                <textarea placeholder="Paste notes / reflection / links here…" rows={4} style={{width:"100%", marginTop:8}}/>
+                <div style={{display:"flex", gap:8, marginTop:8}}>
+                  <button onClick={() => completeModule(m)} disabled={!!done}>
+                    {done ? "Completed ✓" : "Mark Complete"}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <div style={{fontSize:12, color:"#a00"}}>Purchase required to submit work.</div>
+            )}
+          </div>
+        );
+      })}
+    </main>
+  );
+}

--- a/website/pages/dashboard.js
+++ b/website/pages/dashboard.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import BadgeCard from "../components/BadgeCard";
+import { getScout, fetchBadges } from "../lib/store";
+
+export default function Dashboard() {
+  const scout = getScout();
+  const [badges, setBadges] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchBadges()
+      .then(setBadges)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <main style={{maxWidth:800, margin:"40px auto", padding:"0 16px"}}>
+      <h1>Dashboard</h1>
+      <div style={{border:"1px solid #eee", borderRadius:12, padding:12, marginBottom:24}}>
+        <strong>{scout.name || "Scout Name"}</strong> • Troop {scout.troop || "—"}<br/>
+        {scout.city || "City"}, {scout.state || "State"} • Parent: {scout.parentEmail || "—"}
+      </div>
+      <h2>Your Merit Badges</h2>
+      {error && <div style={{color:"#a00"}}>{error}</div>}
+      {!badges && !error && <div>Loading badges…</div>}
+      {badges && badges.map((badge) => (
+        <BadgeCard key={badge.badgeId} badge={badge} />
+      ))}
+    </main>
+  );
+}

--- a/website/pages/index.js
+++ b/website/pages/index.js
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main style={{maxWidth:720, margin:"40px auto", padding:"0 16px"}}>
+      <h1>Thunderbird Merit Badges</h1>
+      <p>
+        Earn badges online at your own pace with instant AI guidance and
+        real Scoutmaster oversight. Your progress saves automatically and
+        prints to a blue-card summary at completion.
+      </p>
+      <p><Link href="/login">Log in</Link> · <Link href="/dashboard">Dashboard</Link></p>
+      <p><Link href="/badges/reading">Try the Reading badge →</Link></p>
+    </main>
+  );
+}

--- a/website/pages/login.js
+++ b/website/pages/login.js
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { setScout, getScout } from "../lib/store";
+import { useRouter } from "next/router";
+
+export default function Login() {
+  const router = useRouter();
+  const seed = getScout();
+  const [form, setForm] = useState(seed);
+  const onSubmit = (e) => {
+    e.preventDefault();
+    setScout(form);
+    router.push("/dashboard");
+  };
+  return (
+    <main style={{maxWidth:600, margin:"40px auto", padding:"0 16px"}}>
+      <h1>Scout Login</h1>
+      <form onSubmit={onSubmit} style={{display:"grid", gap:12}}>
+        <input placeholder="Name" value={form.name} onChange={e=>setForm({...form, name:e.target.value})}/>
+        <input placeholder="Troop #" value={form.troop} onChange={e=>setForm({...form, troop:e.target.value})}/>
+        <input placeholder="Parent Email" value={form.parentEmail} onChange={e=>setForm({...form, parentEmail:e.target.value})}/>
+        <div style={{display:"flex", gap:8}}>
+          <input placeholder="City" value={form.city} onChange={e=>setForm({...form, city:e.target.value})}/>
+          <input placeholder="State" value={form.state} onChange={e=>setForm({...form, state:e.target.value})}/>
+        </div>
+        <button type="submit">Save & Go to Dashboard</button>
+      </form>
+    </main>
+  );
+}

--- a/website/payment.html
+++ b/website/payment.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Thunderbird Merit Badges | Pricing &amp; Payment</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="./scripts.js" defer></script>
+  </head>
+  <body class="page page--payment">
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="brand" href="./index.html">
+          <span class="brand__mark" aria-hidden="true">🦅</span>
+          <span class="brand__text">Thunderbird Merit Badges</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary">
+          <a class="site-nav__link" href="./index.html">Home</a>
+          <a class="site-nav__link" href="./info.html">Badges &amp; Info</a>
+          <a class="site-nav__link" href="./payment.html">Pricing &amp; Payment</a>
+          <a class="site-nav__link site-nav__link--cta" href="./login.html">Scout Login</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="section section--narrow">
+        <div class="section__header">
+          <h1>Flexible pricing for every troop</h1>
+          <p>
+            Thunderbird Merit Badges uses Stripe for secure payment processing.
+            Pay per badge or request a bundle to equip your troop or district.
+          </p>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="pricing-grid">
+          <article class="pricing-card">
+            <h2>Single Badge</h2>
+            <p class="pricing-card__price">$20</p>
+            <ul>
+              <li>Full AI learning pathway</li>
+              <li>Scoutmaster review &amp; sign-off</li>
+              <li>Downloadable completion packet</li>
+            </ul>
+          </article>
+          <article class="pricing-card pricing-card--accent">
+            <h2>Troop Bundle</h2>
+            <p class="pricing-card__price">$85 / 5 badges</p>
+            <ul>
+              <li>Share across scouts</li>
+              <li>Leader analytics dashboard</li>
+              <li>Priority support</li>
+            </ul>
+          </article>
+          <article class="pricing-card">
+            <h2>Urban Troop Scholarship</h2>
+            <p class="pricing-card__price">$12</p>
+            <ul>
+              <li>Income-based discount</li>
+              <li>Sponsored by Thunderbird Foundation</li>
+              <li>Same features as standard plan</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="section section--narrow">
+        <div class="section__header">
+          <h2>Start a payment request</h2>
+          <p>
+            Complete the form below to calculate your total and generate a Stripe
+            checkout link. A confirmation email with the link will arrive within a
+            few minutes.
+          </p>
+        </div>
+
+        <form class="form-card" data-payment-form>
+          <label class="form-field">
+            <span>Contact name</span>
+            <input name="contactName" type="text" required />
+          </label>
+          <label class="form-field">
+            <span>Email address</span>
+            <input name="email" type="email" required />
+          </label>
+          <label class="form-field">
+            <span>Number of badges</span>
+            <input name="badgeCount" type="number" min="1" max="20" value="1" required />
+          </label>
+          <label class="form-field">
+            <span>Discount code (optional)</span>
+            <input name="discountCode" type="text" placeholder="URBAN20" />
+          </label>
+          <label class="form-field">
+            <span>Notes for our team</span>
+            <textarea name="notes" rows="3" placeholder="Include troop number, scheduling requests, or scholarship info."></textarea>
+          </label>
+          <div class="form-actions">
+            <button class="button" type="submit">Calculate &amp; Email Me</button>
+          </div>
+        </form>
+        <div class="callout" role="status" aria-live="polite" data-payment-summary></div>
+      </section>
+
+      <section class="section section--accent">
+        <div class="cta">
+          <div>
+            <h2>Need an invoice or purchase order?</h2>
+            <p>
+              District coordinators can email
+              <a href="mailto:finance@thunderbirdbadges.org">finance@thunderbirdbadges.org</a>
+              for invoicing or grant paperwork.
+            </p>
+          </div>
+          <div class="cta__actions">
+            <a class="button button--light" href="mailto:finance@thunderbirdbadges.org">Contact Finance</a>
+            <a class="button button--outline" href="./login.html">Return to Login</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>Payments processed securely by Stripe. PCI compliant.</p>
+    </footer>
+  </body>
+</html>

--- a/website/scripts.js
+++ b/website/scripts.js
@@ -1,0 +1,492 @@
+const BADGE_CATALOG = [
+  {
+    name: "Citizenship in the Community",
+    focus: "Service project planning, community interviews, and civic participation.",
+    length: "4-6 weeks",
+    category: "Civic Engagement",
+  },
+  {
+    name: "Citizenship in the Nation",
+    focus: "National history, constitutional principles, and communicating with elected officials.",
+    length: "3-5 weeks",
+    category: "Civic Engagement",
+  },
+  {
+    name: "Citizenship in the World",
+    focus: "Global awareness, international organizations, and cultural appreciation activities.",
+    length: "4-6 weeks",
+    category: "Global Citizenship",
+  },
+  {
+    name: "Family Life",
+    focus: "Family meetings, responsibilities, and goal planning with trusted adults.",
+    length: "3 months",
+    category: "Personal Growth",
+  },
+  {
+    name: "Personal Fitness",
+    focus: "Health assessments, exercise plans, and wellness reflections.",
+    length: "3 months",
+    category: "Wellness",
+  },
+  {
+    name: "Personal Management",
+    focus: "Budget tracking, time management, and savings goals.",
+    length: "3 months",
+    category: "Life Skills",
+  },
+];
+
+const STORAGE_KEY = "thunderbirdScout";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+const paceLabels = {
+  weekly: "Weekly check-ins",
+  biweekly: "Every other week",
+  monthly: "Monthly",
+};
+
+function updateYear() {
+  document.querySelectorAll("[data-year]").forEach((node) => {
+    node.textContent = new Date().getFullYear();
+  });
+}
+
+function renderBadgeSelect(container) {
+  if (!container) return;
+  BADGE_CATALOG.forEach((badge, index) => {
+    const id = `badge-${index}`;
+    const label = document.createElement("label");
+    const checkbox = document.createElement("input");
+    const details = document.createElement("div");
+    const title = document.createElement("strong");
+    const focus = document.createElement("span");
+
+    checkbox.type = "checkbox";
+    checkbox.id = id;
+    checkbox.name = "badges";
+    checkbox.value = badge.name;
+
+    title.textContent = badge.name;
+    focus.textContent = badge.focus;
+    focus.className = "badge-select__focus";
+
+    label.htmlFor = id;
+    details.appendChild(title);
+    details.appendChild(document.createElement("br"));
+    details.appendChild(focus);
+
+    label.append(checkbox, details);
+    container.appendChild(label);
+  });
+}
+
+function renderBadgeGrid(container) {
+  if (!container) return;
+  BADGE_CATALOG.forEach((badge) => {
+    const card = document.createElement("article");
+    card.className = "badge-card";
+
+    const title = document.createElement("h3");
+    title.textContent = badge.name;
+
+    const tag = document.createElement("span");
+    tag.className = "badge-card__tag";
+    tag.textContent = badge.category;
+
+    const focus = document.createElement("p");
+    focus.textContent = badge.focus;
+
+    const length = document.createElement("p");
+    length.innerHTML = `<strong>Typical duration:</strong> ${badge.length}`;
+
+    card.append(title, tag, focus, length);
+    container.appendChild(card);
+  });
+}
+
+function loadScoutProfile() {
+  const stored = window.localStorage?.getItem(STORAGE_KEY);
+  if (!stored) return null;
+  try {
+    return JSON.parse(stored);
+  } catch (error) {
+    console.error("Unable to parse stored scout profile", error);
+    return null;
+  }
+}
+
+function saveScoutProfile(profile) {
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, JSON.stringify(profile));
+  } catch (error) {
+    console.error("Unable to save scout profile", error);
+  }
+}
+
+function handleLoginForm(form) {
+  if (!form) return;
+  renderBadgeSelect(form.querySelector("[data-badge-list]"));
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(form);
+    const name = formData.get("scoutName")?.toString().trim();
+    const troop = formData.get("troop")?.toString().trim();
+    const parentEmail = formData.get("parentEmail")?.toString().trim();
+    const contactPhone = formData.get("contactPhone")?.toString().trim();
+    const pace = formData.get("pace")?.toString();
+    const selectedBadges = formData.getAll("badges").map((badge) => badge.toString());
+
+    if (!name || !troop || !parentEmail) {
+      form.reportValidity();
+      return;
+    }
+
+    const profile = {
+      name,
+      troop,
+      parentEmail,
+      contactPhone,
+      pace: pace || "weekly",
+      createdAt: new Date().toISOString(),
+      badges: selectedBadges.map((badgeName) => ({
+        name: badgeName,
+        progress: badgeName.includes("Citizenship") ? 40 : 10,
+        status: "In Progress",
+      })),
+    };
+
+    if (profile.badges.length === 0) {
+      profile.badges.push({
+        name: BADGE_CATALOG[0].name,
+        progress: 10,
+        status: "In Progress",
+      });
+    }
+
+    saveScoutProfile(profile);
+    window.location.href = "./dashboard.html";
+  });
+}
+
+function createBadgeProgressElement(badge, index, totalBadges) {
+  const container = document.createElement("article");
+  container.className = "badge-progress";
+  container.dataset.badgeIndex = index.toString();
+
+  const header = document.createElement("div");
+  header.className = "badge-progress__header";
+
+  const title = document.createElement("h4");
+  title.textContent = badge.name;
+
+  const progressLabel = document.createElement("span");
+  progressLabel.textContent = `${Math.round(badge.progress)}%`;
+
+  const progress = document.createElement("div");
+  progress.className = "progress";
+
+  const bar = document.createElement("div");
+  bar.className = "progress__bar";
+  bar.style.width = `${Math.min(100, badge.progress)}%`;
+  bar.setAttribute("aria-hidden", "true");
+
+  progress.appendChild(bar);
+
+  header.append(title, progressLabel);
+
+  const actions = document.createElement("div");
+  actions.className = "badge-progress__actions";
+
+  const advanceButton = document.createElement("button");
+  advanceButton.type = "button";
+  advanceButton.className = "button button--ghost";
+  advanceButton.textContent = "Log Progress (+10%)";
+  advanceButton.addEventListener("click", () => updateBadgeProgress(index, 10));
+
+  const completeButton = document.createElement("button");
+  completeButton.type = "button";
+  completeButton.className = "button";
+  completeButton.textContent = "Mark Complete";
+  completeButton.addEventListener("click", () => updateBadgeProgress(index, 100));
+
+  const removeButton = document.createElement("button");
+  removeButton.type = "button";
+  removeButton.className = "button button--ghost";
+  removeButton.dataset.action = "remove";
+  removeButton.dataset.index = index.toString();
+  removeButton.textContent = "Remove Badge";
+  removeButton.addEventListener("click", () => removeBadge(index));
+
+  actions.append(advanceButton, completeButton, removeButton);
+
+  if (badge.progress >= 100) {
+    const status = document.createElement("span");
+    status.className = "badge-card__tag";
+    status.textContent = "Complete";
+    actions.appendChild(status);
+    advanceButton.disabled = true;
+    completeButton.disabled = true;
+    container.classList.add("badge-progress--complete");
+  }
+
+  container.append(header, progress, actions);
+  container.dataset.badgeCount = totalBadges.toString();
+  return container;
+}
+
+function renderDashboard(profile) {
+  const emptyState = document.querySelector("[data-dashboard-empty]");
+  const content = document.querySelector("[data-dashboard-content]");
+  if (!emptyState || !content) return;
+
+  if (!profile) {
+    emptyState.hidden = false;
+    content.hidden = true;
+    return;
+  }
+
+  emptyState.hidden = true;
+  content.hidden = false;
+
+  const nameField = document.querySelector("[data-scout-name]");
+  const troopField = document.querySelector("[data-scout-troop]");
+  const paceField = document.querySelector("[data-scout-pace]");
+
+  if (nameField) nameField.textContent = profile.name;
+  if (troopField) troopField.textContent = profile.troop;
+  if (paceField) paceField.textContent = paceLabels[profile.pace] || "Custom";
+
+  let badges = [];
+  if (Array.isArray(profile.badges)) {
+    badges = profile.badges;
+  } else {
+    profile.badges = [];
+    badges = profile.badges;
+  }
+
+  const badgeContainer = document.querySelector("[data-badge-progress]");
+  if (badgeContainer) {
+    badgeContainer.innerHTML = "";
+    badges.forEach((badge, index) => {
+      badgeContainer.appendChild(createBadgeProgressElement(badge, index, badges.length));
+    });
+  }
+
+  const addBadgeSelect = document.querySelector("[data-add-badge-form] select");
+  if (addBadgeSelect) {
+    addBadgeSelect.innerHTML = "";
+    const unselectedBadges = BADGE_CATALOG.filter(
+      (badge) => !badges.some((item) => item.name === badge.name)
+    );
+    unselectedBadges.forEach((badge) => {
+      const option = document.createElement("option");
+      option.value = badge.name;
+      option.textContent = badge.name;
+      addBadgeSelect.appendChild(option);
+    });
+    if (!addBadgeSelect.options.length) {
+      const option = document.createElement("option");
+      option.textContent = "All Eagle-required badges added";
+      option.disabled = true;
+      addBadgeSelect.appendChild(option);
+    }
+  }
+
+  updateNextAction(profile);
+}
+
+function updateBadgeProgress(index, delta) {
+  const profile = loadScoutProfile();
+  if (!profile) return;
+  if (!Array.isArray(profile.badges)) {
+    profile.badges = [];
+  }
+  const badge = profile.badges[index];
+  if (!badge) return;
+
+  if (delta >= 100) {
+    badge.progress = 100;
+    badge.status = "Complete";
+  } else {
+    badge.progress = Math.min(100, badge.progress + delta);
+    badge.status = badge.progress >= 100 ? "Complete" : "In Progress";
+  }
+
+  saveScoutProfile(profile);
+  renderDashboard(profile);
+}
+
+function updateNextAction(profile) {
+  const recommendation = document.querySelector("[data-next-action]");
+  if (!recommendation) return;
+
+  const badges = Array.isArray(profile.badges) ? profile.badges : [];
+
+  if (!badges.length) {
+    recommendation.textContent = "Add your first badge to unlock personalized guidance.";
+    return;
+  }
+
+  const inProgress = badges.find((badge) => badge.progress < 100);
+  if (!inProgress) {
+    recommendation.textContent = "All selected badges are complete! Download your blue card summary and notify your Scoutmaster.";
+    return;
+  }
+
+  if (inProgress.name.includes("Citizenship")) {
+    recommendation.textContent = `Schedule an interview with a community leader for ${inProgress.name}. Use the AI guide to prep your questions.`;
+  } else if (inProgress.name === "Personal Fitness") {
+    recommendation.textContent = "Log this week's fitness test results and reflect on improvements with the AI coach.";
+  } else if (inProgress.name === "Personal Management") {
+    recommendation.textContent = "Upload your latest budget tracker and ask the AI mentor to review savings goals.";
+  } else {
+    recommendation.textContent = `Review your notes for ${inProgress.name} and record a reflection before your next check-in.`;
+  }
+}
+
+function handleAddBadgeForm() {
+  const form = document.querySelector("[data-add-badge-form]");
+  if (!form) return;
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const select = form.querySelector("select");
+    if (!select || !select.value) return;
+
+    const profile = loadScoutProfile();
+    if (!profile) return;
+    if (!Array.isArray(profile.badges)) {
+      profile.badges = [];
+    }
+
+    const alreadyAdded = profile.badges.some((badge) => badge.name === select.value);
+    if (alreadyAdded) return;
+
+    profile.badges.push({ name: select.value, progress: 0, status: "Not Started" });
+    saveScoutProfile(profile);
+    renderDashboard(profile);
+    form.reset();
+  });
+}
+
+function handleSummaryDownload() {
+  const button = document.querySelector("[data-download-summary]");
+  if (!button) return;
+
+  button.addEventListener("click", () => {
+    const profile = loadScoutProfile();
+    if (!profile) return;
+    const badges = Array.isArray(profile.badges) ? profile.badges : [];
+
+    const lines = [
+      `Scout: ${profile.name} (Troop ${profile.troop})`,
+      `Parent/Guardian: ${profile.parentEmail}`,
+      "",
+      "Badge Progress:",
+      ...badges.map((badge) => ` - ${badge.name}: ${Math.round(badge.progress)}% (${badge.status})`),
+      "",
+      "Generated by Thunderbird Merit Badges",
+    ];
+
+    const blob = new Blob([lines.join("\n")], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${profile.name.replace(/\s+/g, "_")}_badge_summary.txt`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  });
+}
+
+function handlePaymentForm(form) {
+  if (!form) return;
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const summary = document.querySelector("[data-payment-summary]");
+    if (!summary) return;
+
+    const formData = new FormData(form);
+    const contactName = formData.get("contactName")?.toString().trim();
+    const email = formData.get("email")?.toString().trim();
+    const badgeCount = Number.parseInt(formData.get("badgeCount"), 10) || 0;
+    const discountCode = formData.get("discountCode")?.toString().trim().toUpperCase();
+
+    if (!contactName || !email || badgeCount <= 0) {
+      form.reportValidity();
+      return;
+    }
+
+    const pricing = calculatePricing(badgeCount, discountCode);
+
+    summary.innerHTML = `
+      <h3>Payment summary</h3>
+      <p><strong>Total due:</strong> ${currencyFormatter.format(pricing.total)}</p>
+      <p>
+        We'll send a secure Stripe checkout link to <strong>${email}</strong> with
+        the details below within a few minutes.
+      </p>
+      <ul>
+        <li>Contact: ${contactName}</li>
+        <li>Badges requested: ${badgeCount}</li>
+        <li>Discounts applied: ${pricing.notes.join(", ") || "None"}</li>
+      </ul>
+    `;
+  });
+}
+
+function calculatePricing(badgeCount, discountCode) {
+  let total = badgeCount * 20;
+  const notes = [];
+
+  if (badgeCount >= 5) {
+    const bundleTotal = Math.round(badgeCount * 20 * 0.85 * 100) / 100;
+    notes.push("Troop bundle (15% off)");
+    total = bundleTotal;
+  }
+
+  if (discountCode === "URBAN20") {
+    total = Math.round(total * 0.8 * 100) / 100;
+    notes.push("Urban troop scholarship (20% off)");
+  } else if (discountCode === "EAGLEDUO") {
+    total = Math.round(total * 0.9 * 100) / 100;
+    notes.push("Eagle Duo 10% savings");
+  }
+
+  return { total, notes };
+}
+
+function initPage() {
+  updateYear();
+  handleLoginForm(document.querySelector("[data-login-form]"));
+  renderBadgeGrid(document.querySelector("[data-badge-grid]"));
+  const profile = loadScoutProfile();
+  renderDashboard(profile);
+  handleAddBadgeForm();
+  handleSummaryDownload();
+  handlePaymentForm(document.querySelector("[data-payment-form]"));
+
+}
+
+function removeBadge(index) {
+  const profile = loadScoutProfile();
+  if (!profile) return;
+  if (!Array.isArray(profile.badges)) {
+    profile.badges = [];
+  }
+  profile.badges.splice(index, 1);
+  saveScoutProfile(profile);
+  renderDashboard(profile);
+}
+
+document.addEventListener("DOMContentLoaded", initPage);

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,635 @@
+:root {
+  color-scheme: light;
+  --color-background: #f7f9fb;
+  --color-surface: #ffffff;
+  --color-surface-alt: #eef3fb;
+  --color-accent: #1d4ed8;
+  --color-accent-light: #3b82f6;
+  --color-accent-soft: rgba(59, 130, 246, 0.12);
+  --color-text: #102037;
+  --color-muted: #5b6b83;
+  --color-border: #d7deea;
+  --color-success: #10b981;
+  --shadow-soft: 0 18px 40px -24px rgba(15, 23, 42, 0.45);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+main {
+  flex: 1;
+}
+
+.site-header {
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--color-text);
+}
+
+.brand__mark {
+  font-size: 1.5rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.site-nav__link {
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.site-nav__link:hover,
+.site-nav__link:focus {
+  background: var(--color-surface-alt);
+  text-decoration: none;
+}
+
+.site-nav__link--cta {
+  color: var(--color-surface);
+  background: var(--color-accent);
+}
+
+.site-nav__link--cta:hover,
+.site-nav__link--cta:focus {
+  background: var(--color-accent-light);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: 2.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 3rem;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.hero__subtitle {
+  max-width: 34rem;
+  color: var(--color-muted);
+  font-size: 1.05rem;
+}
+
+.hero__actions {
+  margin-top: 1.75rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero__panel {
+  display: flex;
+  justify-content: center;
+}
+
+.hero__card {
+  background: var(--color-surface);
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  box-shadow: var(--shadow-soft);
+  min-width: 260px;
+}
+
+.hero__card-title {
+  margin-top: 0;
+}
+
+.hero__badge-list {
+  margin: 1rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--color-muted);
+}
+
+.section {
+  padding: 3.5rem 1.5rem;
+}
+
+.section--light {
+  background: var(--color-surface);
+}
+
+.section--accent {
+  background: linear-gradient(135deg, var(--color-accent) 0%, #0f172a 100%);
+  color: #f8fbff;
+}
+
+.section--narrow {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.section__header {
+  max-width: 760px;
+  margin: 0 auto 2rem;
+  text-align: center;
+}
+
+.section__header h2,
+.section__header h1 {
+  margin-bottom: 0.75rem;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.feature-card {
+  background: var(--color-surface);
+  padding: 1.75rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.steps {
+  counter-reset: steps;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.steps__item {
+  background: var(--color-surface);
+  padding: 1.75rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  position: relative;
+  padding-top: 2.5rem;
+}
+
+.steps__item::before {
+  counter-increment: steps;
+  content: counter(steps);
+  position: absolute;
+  top: -1rem;
+  left: 1.5rem;
+  background: var(--color-accent);
+  color: white;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  box-shadow: 0 12px 24px -18px rgba(59, 130, 246, 0.8);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.9rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--color-accent);
+  color: white;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px -22px rgba(29, 78, 216, 0.9);
+  text-decoration: none;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent);
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  background: var(--color-accent-soft);
+}
+
+.button--light {
+  background: white;
+  color: var(--color-accent);
+}
+
+.button--outline {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  color: white;
+}
+
+.button--outline:hover,
+.button--outline:focus {
+  background: rgba(15, 23, 42, 0.25);
+}
+
+.button--light:hover,
+.button--light:focus {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.cta {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.cta__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2.5rem 1rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.form-card {
+  background: var(--color-surface);
+  border-radius: 1.25rem;
+  padding: 2.5rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.form-fieldset > legend {
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.form-field input,
+.form-field textarea,
+.inline-form select {
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  padding: 0.7rem 1rem;
+  font: inherit;
+  width: 100%;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus,
+.form-field textarea:focus,
+.inline-form select:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+  outline: none;
+}
+
+.form-help {
+  color: var(--color-muted);
+  margin-top: -0.25rem;
+}
+
+.form-actions {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.form-footnote {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.radio-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0;
+}
+
+.badge-select {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.badge-select label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+}
+
+.badge-select input {
+  margin-top: 0.3rem;
+}
+
+.badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.badge-card {
+  background: var(--color-surface);
+  padding: 1.75rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.badge-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.info-split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.info-panel {
+  background: var(--color-surface);
+  padding: 2rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.checklist {
+  margin: 1rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+}
+
+.pricing-grid {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.pricing-card {
+  background: var(--color-surface);
+  padding: 2rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+}
+
+.pricing-card__price {
+  font-size: 2.5rem;
+  margin: 0.5rem 0 1rem;
+  color: var(--color-accent);
+}
+
+.pricing-card--accent {
+  border: 2px solid var(--color-accent);
+}
+
+.callout {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 0.9rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.callout--info {
+  background: var(--color-surface-alt);
+}
+
+.dashboard {
+  display: grid;
+  gap: 2rem;
+}
+
+.dashboard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.dashboard__panel {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.dashboard__badges {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.badge-progress {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.badge-progress__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.progress {
+  width: 100%;
+  height: 0.75rem;
+  background: var(--color-surface-alt);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress__bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--color-accent) 0%, var(--color-accent-light) 100%);
+  transition: width 0.4s ease;
+}
+
+.badge-progress__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.badge-progress__actions button {
+  font-size: 0.9rem;
+  padding: 0.45rem 0.9rem;
+}
+
+.badge-progress--complete .progress__bar {
+  background: linear-gradient(90deg, var(--color-success) 0%, #34d399 100%);
+}
+
+.badge-progress--complete .badge-progress__header span {
+  color: var(--color-success);
+}
+
+.badge-progress__actions .badge-card__tag {
+  border: none;
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--color-success);
+}
+
+.inline-form {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.inline-form__field {
+  min-width: 220px;
+}
+
+.dashboard__recommendation {
+  color: var(--color-muted);
+  font-size: 1rem;
+}
+
+.callout[hidden],
+[data-dashboard-content][hidden],
+[data-dashboard-empty][hidden] {
+  display: none !important;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding-top: 3rem;
+  }
+
+  .hero__panel {
+    order: -1;
+  }
+
+  .form-card {
+    padding: 1.75rem;
+  }
+
+  .site-header__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .site-nav {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .cta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a manifest API route that indexes every badge JSON in /data and expose a fetch helper for the dashboard
- update the dashboard to load badges from the manifest and show loading/error states, and surface badge resources on the detail page
- enrich every badge seed with official requirement links and resource lists, including the refreshed Reading badge content

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d30c9f7c40832d92bb86c5886fced1